### PR TITLE
Make AWS credentials optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,15 @@ Pass "s3" to the setType method when creating ConfigStoreOptions. The configurat
 - the object key
 - the bucket where the object can be found
 - the region
-- an AWS access key
-- an AWS secret access key
+- an AWS access key (optional)
+- an AWS secret access key (optional)
+
+If AWS access key and secret access key are not provided, the DefaultCredentialsProvider will look for credentials in this order:
+  1. Java System Properties - aws.accessKeyId and aws.secretAccessKey
+  2. Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+  3. Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI
+  4. Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" environment variable is set and security manager has permission to access the variable,
+  5. Instance profile credentials delivered through the Amazon EC2 metadata service
 
 ```
 ConfigStoreOptions s3 = new ConfigStoreOptions()

--- a/src/main/java/com/github/mikelee2082/vertx/config/s3/S3ConfigStore.java
+++ b/src/main/java/com/github/mikelee2082/vertx/config/s3/S3ConfigStore.java
@@ -26,12 +26,16 @@ public class S3ConfigStore implements ConfigStore {
 
 	public S3ConfigStore(Vertx vertx, JsonObject config) {
 		try {
-			AwsCredentials creds = AwsBasicCredentials.create(config.getString("access_key"), config.getString("secret_access_key"));
-			AwsCredentialsProvider provider = StaticCredentialsProvider.create(creds);
 			key = config.getString("key");
 			bucket = config.getString("bucket");
 			region = Region.of(config.getString("region"));
-			S3ClientBuilder builder = S3Client.builder().region(region).credentialsProvider(provider);
+			S3ClientBuilder builder = S3Client.builder().region(region);
+            if (config.containsKey("access_key") && config.containsKey("secret_access_key")) {
+                AwsCredentials creds = AwsBasicCredentials.create(config.getString("access_key"),
+                    config.getString("secret_access_key"));
+                AwsCredentialsProvider provider = StaticCredentialsProvider.create(creds);
+                builder = builder.credentialsProvider(provider);
+              }
 			if (config.containsKey("endpoint_url")) {
 				builder = builder.endpointOverride(new URI(config.getString("endpoint_url")));
 			}


### PR DESCRIPTION
Hi Mike,
I was unable to put my AWS credentials in code, so I tweaked the config store to make the credentials optional and rely on the DefaultCredentialsProvider. 
See [Use the default credential provider chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html)
Regards,
Bill